### PR TITLE
feat: add item owner and assistant labels

### DIFF
--- a/backend/src/main/java/app/listful/domain/Item.java
+++ b/backend/src/main/java/app/listful/domain/Item.java
@@ -56,6 +56,12 @@ public class Item {
     @Column(name = "last_completed_at")
     private Instant lastCompletedAt;
 
+    @Column(name = "owner_label")
+    private String ownerLabel;
+
+    @Column(name = "assistant_labels")
+    private String assistantLabels;
+
     protected Item() {
     }
 
@@ -84,6 +90,10 @@ public class Item {
     }
 
     public void update(String name, String description, String url, String imageUrl, BigDecimal price, ItemStatus status, Instant dueDate, String recurrenceRule, String quantity, String category) {
+        update(name, description, url, imageUrl, price, status, dueDate, recurrenceRule, quantity, category, null, null);
+    }
+
+    public void update(String name, String description, String url, String imageUrl, BigDecimal price, ItemStatus status, Instant dueDate, String recurrenceRule, String quantity, String category, String ownerLabel, String assistantLabels) {
         this.name = name;
         this.description = description;
         this.url = url;
@@ -94,6 +104,8 @@ public class Item {
         this.recurrenceRule = recurrenceRule;
         this.quantity = quantity;
         this.category = category;
+        this.ownerLabel = ownerLabel;
+        this.assistantLabels = assistantLabels;
     }
 
     public String getId() { return id; }
@@ -120,4 +132,6 @@ public class Item {
     public String getReservedByGuest() { return reservedByGuest; }
     public Instant getLastCompletedAt() { return lastCompletedAt; }
     public void setLastCompletedAt(Instant lastCompletedAt) { this.lastCompletedAt = lastCompletedAt; }
+    public String getOwnerLabel() { return ownerLabel; }
+    public String getAssistantLabels() { return assistantLabels; }
 }

--- a/backend/src/main/java/app/listful/items/ItemService.java
+++ b/backend/src/main/java/app/listful/items/ItemService.java
@@ -44,7 +44,7 @@ public class ItemService {
         validateForListType(list, request);
         String itemName = itemNameFor(request);
         Item item = new Item(list, itemName, Instant.now());
-        item.update(itemName, request.description(), request.url(), request.imageUrl(), request.price(), request.status(), request.dueDate(), request.recurrenceRule(), request.quantity(), request.category());
+        item.update(itemName, request.description(), request.url(), request.imageUrl(), request.price(), request.status(), request.dueDate(), request.recurrenceRule(), request.quantity(), request.category(), trimmedOrNull(request.ownerLabel()), trimmedOrNull(request.assistantLabels()));
         Item saved = itemRepository.save(item);
         if (shouldEnrichWishUrlItem(list, request)) {
             itemEnrichmentService.enrichUrlItem(saved.getId(), request.url().trim());
@@ -56,7 +56,7 @@ public class ItemService {
     public ItemResponse update(User actor, String itemId, ItemRequest request) {
         Item item = requireContributableItem(actor, itemId);
         validateForListType(item.getList(), request);
-        item.update(request.name(), request.description(), request.url(), request.imageUrl(), request.price(), request.status(), request.dueDate(), request.recurrenceRule(), request.quantity(), request.category());
+        item.update(request.name(), request.description(), request.url(), request.imageUrl(), request.price(), request.status(), request.dueDate(), request.recurrenceRule(), request.quantity(), request.category(), trimmedOrNull(request.ownerLabel()), trimmedOrNull(request.assistantLabels()));
         advanceCompletedRecurringChore(item);
         return toResponse(item);
     }
@@ -173,6 +173,10 @@ public class ItemService {
         return value != null && !value.isBlank();
     }
 
+    private String trimmedOrNull(String value) {
+        return hasText(value) ? value.trim() : null;
+    }
+
     private void advanceCompletedRecurringChore(Item item) {
         if (item.getList().getType() == ListType.CHORE
                 && item.getStatus() == ItemStatus.DONE
@@ -234,7 +238,9 @@ public class ItemService {
             item.getQuantity(),
             item.getCategory(),
             item.getReservedByGuest(),
-            item.getLastCompletedAt() == null ? null : item.getLastCompletedAt().toString()
+            item.getLastCompletedAt() == null ? null : item.getLastCompletedAt().toString(),
+            item.getOwnerLabel(),
+            item.getAssistantLabels()
         );
     }
 }

--- a/backend/src/main/java/app/listful/items/dto/ItemRequest.java
+++ b/backend/src/main/java/app/listful/items/dto/ItemRequest.java
@@ -15,6 +15,8 @@ public record ItemRequest(
     Instant dueDate,
     @Size(max = 255) String recurrenceRule,
     @Size(max = 255) String quantity,
-    @Size(max = 255) String category
+    @Size(max = 255) String category,
+    @Size(max = 255) String ownerLabel,
+    @Size(max = 255) String assistantLabels
 ) {
 }

--- a/backend/src/main/java/app/listful/items/dto/ItemResponse.java
+++ b/backend/src/main/java/app/listful/items/dto/ItemResponse.java
@@ -16,6 +16,8 @@ public record ItemResponse(
     String quantity,
     String category,
     String reservedByGuest,
-    String lastCompletedAt
+    String lastCompletedAt,
+    String ownerLabel,
+    String assistantLabels
 ) {
 }

--- a/backend/src/main/resources/db/migration/V12__add_item_responsibility_labels.sql
+++ b/backend/src/main/resources/db/migration/V12__add_item_responsibility_labels.sql
@@ -1,0 +1,2 @@
+ALTER TABLE items ADD COLUMN owner_label TEXT;
+ALTER TABLE items ADD COLUMN assistant_labels TEXT;

--- a/backend/src/test/java/app/listful/items/ItemControllerTests.java
+++ b/backend/src/test/java/app/listful/items/ItemControllerTests.java
@@ -266,6 +266,32 @@ class ItemControllerTests {
     }
 
     @Test
+    void choreItemsCarryGenericOwnerAndAssistantLabels() throws Exception {
+        MockHttpSession owner = register("owner");
+        String choreId = createList(owner, "Household rotation", "CHORE");
+
+        MvcResult created = mockMvc.perform(post("/api/v1/lists/{listId}/items", choreId).session(owner)
+                .contentType("application/json")
+                .content("""
+                    {"name":"Water plants","dueDate":"2027-01-01T09:00:00Z","recurrenceRule":"FREQ=WEEKLY","ownerLabel":"Resident on plants","assistantLabels":"Reminder bot; backup helper"}
+                    """))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.ownerLabel").value("Resident on plants"))
+            .andExpect(jsonPath("$.assistantLabels").value("Reminder bot; backup helper"))
+            .andReturn();
+        String itemId = JsonPath.read(created.getResponse().getContentAsString(), "$.id");
+
+        mockMvc.perform(put("/api/v1/items/{itemId}", itemId).session(owner)
+                .contentType("application/json")
+                .content("""
+                    {"name":"Water plants","status":"OPEN","dueDate":"2027-01-01T09:00:00Z","recurrenceRule":"FREQ=WEEKLY","ownerLabel":"Plant owner","assistantLabels":"Local assistant"}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.ownerLabel").value("Plant owner"))
+            .andExpect(jsonPath("$.assistantLabels").value("Local assistant"));
+    }
+
+    @Test
     void unsupportedChoreRecurrenceFailsClearly() throws Exception {
         MockHttpSession owner = register("owner");
         String choreId = createList(owner, "Chores", "CHORE");

--- a/backend/src/test/java/app/listful/items/ItemControllerTests.java
+++ b/backend/src/test/java/app/listful/items/ItemControllerTests.java
@@ -411,7 +411,7 @@ class ItemControllerTests {
     }
 
     private void awaitItemName(String itemId, String expectedName) throws InterruptedException {
-        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
         while (System.nanoTime() < deadline) {
             String currentName = itemRepository.findById(itemId).orElseThrow().getName();
             if (expectedName.equals(currentName)) {
@@ -423,7 +423,7 @@ class ItemControllerTests {
     }
 
     private void awaitItemPrice(String itemId, BigDecimal expectedPrice) throws InterruptedException {
-        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
         while (System.nanoTime() < deadline) {
             BigDecimal currentPrice = itemRepository.findById(itemId).orElseThrow().getPrice();
             if (currentPrice != null && expectedPrice.compareTo(currentPrice) == 0) {

--- a/backend/src/test/java/app/listful/persistence/SchemaMigrationTests.java
+++ b/backend/src/test/java/app/listful/persistence/SchemaMigrationTests.java
@@ -47,4 +47,15 @@ class SchemaMigrationTests {
             "idx_list_shares_user_id"
         );
     }
+
+    @Test
+    void flywayCreatesItemResponsibilityColumns() {
+        List<String> columns = jdbcTemplate.queryForList(
+            "select name from pragma_table_info('items')",
+            String.class
+        );
+
+        assertThat(columns).contains("owner_label", "assistant_labels");
+    }
+
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -190,7 +190,7 @@ Creates an item on an owned list or a list shared with `CONTRIBUTE` permission.
 Request:
 
 ```json
-{"name":"Camera strap","description":"Leather strap","url":"https://example.test/strap","imageUrl":null,"price":29.90,"status":"OPEN","dueDate":null,"recurrenceRule":null,"quantity":null,"category":null}
+{"name":"Camera strap","description":"Leather strap","url":"https://example.test/strap","imageUrl":null,"price":29.90,"status":"OPEN","dueDate":null,"recurrenceRule":null,"quantity":null,"category":null,"ownerLabel":"Responsible role","assistantLabels":"Local assistant"}
 ```
 
 Response: `201 Created` with item.
@@ -209,8 +209,9 @@ Type validation:
 - `TODO` items reject shopping fields and recurrence rules, and allow `dueDate` for reminders.
 - `GROCERY` items allow `quantity` and `category`, and reject shopping fields, due dates, and recurrence rules.
 - `CHORE` items reject shopping fields and allow `dueDate` plus `recurrenceRule`.
-- Supported chore recurrence rules are `FREQ=DAILY`, `FREQ=WEEKLY`, and `FREQ=MONTHLY`.
+- Supported chore recurrence rules are `FREQ=DAILY`, `FREQ=WEEKLY`, `FREQ=BIWEEKLY`, `FREQ=MONTHLY`, `FREQ=QUARTERLY`, and `FREQ=ANNUALLY`.
 - `EVENT` items reject shopping fields and `recurrenceRule`, and allow `dueDate`.
+- `ownerLabel` and `assistantLabels` are optional coordination metadata for work-style items. They may name people, roles, bots, or local automations; they do not grant access or notification rights.
 
 ### `PUT /api/v1/items/{id}`
 
@@ -243,7 +244,7 @@ Deletes `DONE` items from an owned `GROCERY` list. This is the shop-mode reset p
 Item response:
 
 ```json
-{"id":"uuid","listId":"uuid","name":"Camera strap","description":"Leather strap","url":"https://example.test/strap","imageUrl":null,"price":29.90,"status":"OPEN","dueDate":null,"recurrenceRule":null,"quantity":null,"category":null,"reservedByGuest":null,"lastCompletedAt":null}
+{"id":"uuid","listId":"uuid","name":"Camera strap","description":"Leather strap","url":"https://example.test/strap","imageUrl":null,"price":29.90,"status":"OPEN","dueDate":null,"recurrenceRule":null,"quantity":null,"category":null,"reservedByGuest":null,"lastCompletedAt":null,"ownerLabel":"Responsible role","assistantLabels":"Local assistant"}
 ```
 
 ## Internal sharing

--- a/docs/domain/domain-model.md
+++ b/docs/domain/domain-model.md
@@ -67,6 +67,8 @@ Fields:
 - `quantity`
 - `category`
 - `reserved_by_guest`
+- `owner_label` optional user-visible responsible person/role/agent label
+- `assistant_labels` optional user-visible helper/assistant labels
 
 Rules:
 
@@ -78,6 +80,9 @@ Rules:
 - `DONE` is used by TODO/GROCERY/CHORE/EVENT-style work items.
 - Type-specific fields are interpreted by the parent list type.
 - `quantity` and `category` are grocery-specific.
+- `owner_label` is item-level responsibility metadata, distinct from the registered account that owns the parent list. It may name a household member, roommate, role, or automation/agent label and is intentionally instance-local free text for the MVP.
+- `assistant_labels` records optional helpers or assistants that can support or watch the item. Assistants can be people, roles, bots, or local automations; they do not receive permissions by being named here.
+- Responsibility labels are display/coordination metadata only. Authorization still follows the parent list and internal/public share rules.
 
 ## Settings
 

--- a/docs/domain/list-types.md
+++ b/docs/domain/list-types.md
@@ -57,11 +57,14 @@ Relevant item fields:
 - `name`
 - `due_date`
 - `status`
+- optional `owner_label`
+- optional `assistant_labels`
 
 UI behavior:
 
 - Hide price, image, URL, and recurrence fields.
-- Show due date/time so the reminder scanner can notify the owner.
+- Show due date/time so the reminder scanner can notify the list owner.
+- Show owner and assistant/helper labels for coordination without assuming a concrete family structure.
 
 MVP rules:
 
@@ -111,11 +114,13 @@ Relevant item fields:
 - `due_date`
 - `recurrence_rule`
 - `status`
+- optional `owner_label`
+- optional `assistant_labels`
 
 UI behavior:
 
 - Hide price, image, and URL fields by default.
-- Show due date and recurrence.
+- Show due date, recurrence, owner, and assistant/helper labels.
 
 MVP rules:
 
@@ -148,11 +153,13 @@ Relevant item fields:
 - `name`
 - `due_date`
 - optional `status`
+- optional `owner_label`
+- optional `assistant_labels`
 
 UI behavior:
 
 - Require or strongly prompt for target date.
-- Emphasize due dates and completion state.
+- Emphasize due dates, completion state, owner, and assistant/helper labels.
 - Hide shopping fields unless the event item is explicitly a wishlist-like item in a future extension.
 
 MVP rules:

--- a/docs/product/terminology.md
+++ b/docs/product/terminology.md
@@ -3,7 +3,9 @@
 ## Actor terms
 
 - **Admin:** registered user with instance administration privileges.
-- **Owner:** registered user who created and owns a list.
+- **List owner:** registered user who created and owns a list.
+- **Item owner:** user-visible label for the person, role, or agent responsible for making sure an item happens. This is coordination metadata, not an access grant.
+- **Assistant/helper:** user-visible label for a person, role, bot, or automation assisting with an item. Assistants do not receive permissions by being named.
 - **Registered user:** authenticated account on the same instance.
 - **Internal shared user:** registered user granted access to another user's list.
 - **Guest:** unauthenticated visitor using a public share token.
@@ -11,7 +13,7 @@
 ## Domain terms
 
 - **List:** a collection of items owned by one user. Lists have a type: `WISH`, `TODO`, `GROCERY`, `CHORE`, or `EVENT`.
-- **Item:** an entry inside a list. Fields are interpreted by list type.
+- **Item:** an entry inside a list. Fields are interpreted by list type; work-style items can also carry owner/helper labels.
 - **Share token:** cryptographically random URL-safe token that exposes a public guest view of one list.
 - **Public share mode:** owner-selected behavior for a public link: `VIEW`, `WISH_CLAIM`, or `SIGNUP`.
 - **Internal share:** access grant from a list owner to another registered user, currently `READ` or `CONTRIBUTE`.

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -138,6 +138,14 @@ As a wishlist owner, I want price, URL, and image fields so gift ideas are usefu
 
 As a chore-list owner, I want recurrence and due dates without shopping fields so household tasks stay clear.
 
+### Story: Item responsibility owner
+
+As a household or small-team coordinator, I want a task or chore to show who owns the responsibility so follow-up is clear without hardcoding family-specific names.
+
+### Story: Item assistants/helpers
+
+As a coordinator, I want optional assistant/helper labels on tasks and chores so human helpers, roles, bots, or local automations can be visible without granting extra permissions.
+
 ### Story: Event-specific fields
 
 As an event-list owner, I want a target date and due items so event planning has a deadline.

--- a/frontend/src/App.ownerAssistants.test.js
+++ b/frontend/src/App.ownerAssistants.test.js
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const app = readFileSync(new URL('./App.vue', import.meta.url), 'utf8');
+
+describe('item owner and assistant labels', () => {
+  it('renders create/edit inputs and visible labels without hardcoded household names', () => {
+    expect(app).toContain('v-model="itemForm.ownerLabel"');
+    expect(app).toContain('v-model="itemForm.assistantLabels"');
+    expect(app).toContain('v-model="editItemForm.ownerLabel"');
+    expect(app).toContain('v-model="editItemForm.assistantLabels"');
+    expect(app).toContain("t('items.ownerLabel')");
+    expect(app).toContain("t('items.assistantLabels')");
+    expect(app).not.toMatch(/Uwe|Martha|Alice/);
+  });
+
+  it('sends responsibility metadata through create edit and status-toggle payloads', () => {
+    expect(app).toContain('ownerLabel: itemForm.ownerLabel || undefined');
+    expect(app).toContain('assistantLabels: itemForm.assistantLabels || undefined');
+    expect(app).toContain('ownerLabel: editItemForm.ownerLabel || undefined');
+    expect(app).toContain('assistantLabels: editItemForm.assistantLabels || undefined');
+    expect(app).toContain('ownerLabel: item.ownerLabel ?? undefined');
+    expect(app).toContain('assistantLabels: item.assistantLabels ?? undefined');
+  });
+});

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -224,6 +224,8 @@
               <input v-if="currentItemFields.showQuantity" v-model="itemForm.quantity" :placeholder="t('items.quantity')" />
               <input v-if="currentItemFields.showCategory" v-model="itemForm.category" :placeholder="t('items.category')" />
               <input v-if="currentItemFields.showDueDate" v-model="itemForm.dueDate" type="datetime-local" :placeholder="t('items.dueDate')" />
+              <input v-if="currentItemFields.showResponsibility" v-model="itemForm.ownerLabel" :placeholder="t('items.ownerLabel')" />
+              <input v-if="currentItemFields.showResponsibility" v-model="itemForm.assistantLabels" :placeholder="t('items.assistantLabels')" />
               <select v-if="currentItemFields.showRecurrenceRule" v-model="itemForm.recurrenceRule">
                 <option v-for="option in recurrenceOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
               </select>
@@ -270,12 +272,15 @@
                       <input v-model="editItemForm.name" :placeholder="t('items.newName')" required />
                       <input v-if="currentItemFields.showQuantity" v-model="editItemForm.quantity" :placeholder="t('items.quantity')" />
                       <input v-if="currentItemFields.showCategory" v-model="editItemForm.category" :placeholder="t('items.category')" />
+                      <input v-if="currentItemFields.showResponsibility" v-model="editItemForm.ownerLabel" :placeholder="t('items.ownerLabel')" />
+                      <input v-if="currentItemFields.showResponsibility" v-model="editItemForm.assistantLabels" :placeholder="t('items.assistantLabels')" />
                       <button type="submit">{{ t('items.save') }}</button>
                       <button type="button" class="secondary subtle" @click="handleCancelEditItem">{{ t('items.cancel') }}</button>
                     </form>
                     <span v-else>
                       <strong>{{ item.name }}</strong>
                       <small v-if="item.quantity || item.category"><template v-if="item.quantity">{{ item.quantity }}</template><template v-if="item.quantity && item.category"> · </template><template v-if="item.category">{{ item.category }}</template></small>
+                      <small v-if="item.ownerLabel || item.assistantLabels"><template v-if="item.ownerLabel">{{ t('items.ownerLabel') }}: {{ item.ownerLabel }}</template><template v-if="item.ownerLabel && item.assistantLabels"> · </template><template v-if="item.assistantLabels">{{ t('items.assistantLabels') }}: {{ item.assistantLabels }}</template></small>
                       <small>{{ item.status }}</small>
                     </span>
                     <button v-if="(selectedList.access === 'OWNER' || selectedList.access === 'CONTRIBUTE') && item.status === 'OPEN'" type="button" class="secondary subtle" @click="handleToggleItemDone(item)">{{ t('items.done') }}</button>
@@ -299,6 +304,8 @@
                   <input v-if="currentItemFields.showQuantity" v-model="editItemForm.quantity" :placeholder="t('items.quantity')" />
                   <input v-if="currentItemFields.showCategory" v-model="editItemForm.category" :placeholder="t('items.category')" />
                   <input v-if="currentItemFields.showDueDate" v-model="editItemForm.dueDate" type="datetime-local" :placeholder="t('items.dueDate')" />
+                  <input v-if="currentItemFields.showResponsibility" v-model="editItemForm.ownerLabel" :placeholder="t('items.ownerLabel')" />
+                  <input v-if="currentItemFields.showResponsibility" v-model="editItemForm.assistantLabels" :placeholder="t('items.assistantLabels')" />
                   <select v-if="currentItemFields.showRecurrenceRule" v-model="editItemForm.recurrenceRule">
                     <option v-for="option in recurrenceOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
                   </select>
@@ -309,6 +316,7 @@
                   <strong>{{ item.name }}</strong>
                   <small v-if="item.description">{{ item.description }}</small>
                   <small v-if="item.quantity || item.category"><template v-if="item.quantity">{{ item.quantity }}</template><template v-if="item.quantity && item.category"> · </template><template v-if="item.category">{{ item.category }}</template></small>
+                  <small v-if="item.ownerLabel || item.assistantLabels"><template v-if="item.ownerLabel">{{ t('items.ownerLabel') }}: {{ item.ownerLabel }}</template><template v-if="item.ownerLabel && item.assistantLabels"> · </template><template v-if="item.assistantLabels">{{ t('items.assistantLabels') }}: {{ item.assistantLabels }}</template></small>
                   <small>{{ item.status }}<template v-if="item.price"> · {{ item.price }} €</template><template v-if="item.lastCompletedAt"> · {{ t('items.lastCompleted') }} {{ item.lastCompletedAt }}</template></small>
                 </span>
                 <button v-if="(selectedList.access === 'OWNER' || selectedList.access === 'CONTRIBUTE') && item.status === 'OPEN' && selectedList.type !== 'WISH'" type="button" class="secondary subtle" @click="handleToggleItemDone(item)">{{ t('items.done') }}</button>
@@ -411,9 +419,9 @@ const listForm = reactive<{ title: string; description: string; type: ListType; 
 const editingList = ref(false);
 const pendingDeleteListId = ref<string | null>(null);
 const editListForm = reactive<{ title: string; description: string; type: ListType; targetDate: string }>({ title: '', description: '', type: 'WISH', targetDate: '' });
-const itemForm = reactive({ name: '', description: '', url: '', imageUrl: '', price: undefined as number | undefined, dueDate: '', recurrenceRule: '', quantity: '', category: '' });
+const itemForm = reactive({ name: '', description: '', url: '', imageUrl: '', price: undefined as number | undefined, dueDate: '', recurrenceRule: '', quantity: '', category: '', ownerLabel: '', assistantLabels: '' });
 const editingItemId = ref<string | null>(null);
-const editItemForm = reactive({ name: '', description: '', url: '', imageUrl: '', price: undefined as number | undefined, dueDate: '', recurrenceRule: '', quantity: '', category: '' });
+const editItemForm = reactive({ name: '', description: '', url: '', imageUrl: '', price: undefined as number | undefined, dueDate: '', recurrenceRule: '', quantity: '', category: '', ownerLabel: '', assistantLabels: '' });
 const itemReviewForm = reactive<ItemReviewState>(defaultItemReviewState());
 const itemReviewNow = ref(new Date());
 const recurrenceOptions = computed(() => [
@@ -800,7 +808,9 @@ async function handleCreateItem() {
       dueDate: fields.showDueDate ? toIsoInstant(itemForm.dueDate) : undefined,
       recurrenceRule: fields.showRecurrenceRule ? itemForm.recurrenceRule || undefined : undefined,
       quantity: fields.showQuantity ? itemForm.quantity || undefined : undefined,
-      category: fields.showCategory ? itemForm.category || undefined : undefined
+      category: fields.showCategory ? itemForm.category || undefined : undefined,
+      ownerLabel: itemForm.ownerLabel || undefined,
+      assistantLabels: itemForm.assistantLabels || undefined
     });
     resetItemForm();
     items.value = [created, ...items.value];
@@ -821,6 +831,8 @@ function handleStartEditItem(item: ItemEntry) {
   editItemForm.recurrenceRule = item.recurrenceRule ?? '';
   editItemForm.quantity = item.quantity ?? '';
   editItemForm.category = item.category ?? '';
+  editItemForm.ownerLabel = item.ownerLabel ?? '';
+  editItemForm.assistantLabels = item.assistantLabels ?? '';
 }
 
 function handleCancelEditItem() {
@@ -884,7 +896,9 @@ function itemPayloadFromEditForm(status: ItemEntry['status']) {
     dueDate: fields.showDueDate ? toIsoInstant(editItemForm.dueDate) : undefined,
     recurrenceRule: fields.showRecurrenceRule ? editItemForm.recurrenceRule || undefined : undefined,
     quantity: fields.showQuantity ? editItemForm.quantity || undefined : undefined,
-    category: fields.showCategory ? editItemForm.category || undefined : undefined
+    category: fields.showCategory ? editItemForm.category || undefined : undefined,
+    ownerLabel: editItemForm.ownerLabel || undefined,
+    assistantLabels: editItemForm.assistantLabels || undefined
   };
 }
 
@@ -899,7 +913,9 @@ function itemPayloadFromItem(item: ItemEntry, status: ItemEntry['status']) {
     dueDate: item.dueDate ?? undefined,
     recurrenceRule: item.recurrenceRule ?? undefined,
     quantity: item.quantity ?? undefined,
-    category: item.category ?? undefined
+    category: item.category ?? undefined,
+    ownerLabel: item.ownerLabel ?? undefined,
+    assistantLabels: item.assistantLabels ?? undefined
   };
 }
 
@@ -933,5 +949,7 @@ function resetItemForm() {
   itemForm.recurrenceRule = '';
   itemForm.quantity = '';
   itemForm.category = '';
+  itemForm.ownerLabel = '';
+  itemForm.assistantLabels = '';
 }
 </script>

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -172,8 +172,8 @@ describe('auth API client', () => {
     const fetchMock = mockJsonFetch({ id: 'i1', listId: 'l1', name: 'Camera strap', status: 'OPEN' });
 
     await getItems('l1');
-    await createItem('l1', { name: 'Camera strap' });
-    await updateItem('i1', { name: 'Leather strap', status: 'PURCHASED', price: 29.9 });
+    await createItem('l1', { name: 'Camera strap', ownerLabel: 'Responsible role', assistantLabels: 'Reminder bot' });
+    await updateItem('i1', { name: 'Leather strap', status: 'PURCHASED', price: 29.9, ownerLabel: 'Gift owner', assistantLabels: 'Price watcher' });
     await deleteItem('i1');
     await clearCompletedItems('l1');
     await skipChoreItem('i2');
@@ -183,11 +183,12 @@ describe('auth API client', () => {
     expectApiCall(fetchMock, 2, '/api/v1/lists/l1/items', expect.objectContaining({
       method: 'POST',
       credentials: 'include',
-      body: JSON.stringify({ name: 'Camera strap' })
+      body: JSON.stringify({ name: 'Camera strap', ownerLabel: 'Responsible role', assistantLabels: 'Reminder bot' })
     }));
     expectApiCall(fetchMock, 3, '/api/v1/items/i1', expect.objectContaining({
       method: 'PUT',
-      credentials: 'include'
+      credentials: 'include',
+      body: JSON.stringify({ name: 'Leather strap', status: 'PURCHASED', price: 29.9, ownerLabel: 'Gift owner', assistantLabels: 'Price watcher' })
     }));
     expectApiCall(fetchMock, 4, '/api/v1/items/i1', expect.objectContaining({
       method: 'DELETE',

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -122,6 +122,8 @@ export interface ItemEntry {
   category: string | null;
   reservedByGuest: string | null;
   lastCompletedAt: string | null;
+  ownerLabel: string | null;
+  assistantLabels: string | null;
 }
 
 export interface ItemRequest {
@@ -135,6 +137,8 @@ export interface ItemRequest {
   recurrenceRule?: string;
   quantity?: string;
   category?: string;
+  ownerLabel?: string;
+  assistantLabels?: string;
 }
 
 export interface PostponeRequest {

--- a/frontend/src/itemReview.test.ts
+++ b/frontend/src/itemReview.test.ts
@@ -16,7 +16,9 @@ const baseItem = (overrides: Partial<ItemEntry>): ItemEntry => ({
   quantity: overrides.quantity ?? null,
   category: overrides.category ?? null,
   reservedByGuest: null,
-  lastCompletedAt: null
+  lastCompletedAt: null,
+  ownerLabel: overrides.ownerLabel ?? null,
+  assistantLabels: overrides.assistantLabels ?? null
 });
 
 const state = (overrides: Partial<ItemReviewState> = {}): ItemReviewState => ({

--- a/frontend/src/listTypes.test.ts
+++ b/frontend/src/listTypes.test.ts
@@ -23,21 +23,24 @@ describe('list type UI rules', () => {
       showImageUrl: false,
       showPrice: false,
       showDueDate: true,
-      showRecurrenceRule: true
+      showRecurrenceRule: true,
+      showResponsibility: true
     });
     expect(itemFormFieldsForListType('EVENT')).toEqual({
       showUrl: false,
       showImageUrl: false,
       showPrice: false,
       showDueDate: true,
-      showRecurrenceRule: false
+      showRecurrenceRule: false,
+      showResponsibility: true
     });
     expect(itemFormFieldsForListType('TODO')).toEqual({
       showUrl: false,
       showImageUrl: false,
       showPrice: false,
       showDueDate: true,
-      showRecurrenceRule: false
+      showRecurrenceRule: false,
+      showResponsibility: true
     });
     expect(itemFormFieldsForListType('GROCERY')).toEqual({
       showUrl: false,
@@ -46,7 +49,8 @@ describe('list type UI rules', () => {
       showDueDate: false,
       showRecurrenceRule: false,
       showQuantity: true,
-      showCategory: true
+      showCategory: true,
+      showResponsibility: true
     });
   });
 });

--- a/frontend/src/listTypes.ts
+++ b/frontend/src/listTypes.ts
@@ -13,6 +13,7 @@ export type ItemFormFields = {
   showRecurrenceRule: boolean;
   showQuantity?: boolean;
   showCategory?: boolean;
+  showResponsibility?: boolean;
 };
 
 export function listFormRulesForType(type: ListType): ListFormRules {
@@ -29,6 +30,7 @@ export function itemFormFieldsForListType(type: ListType): ItemFormFields {
     showPrice: type === 'WISH',
     showDueDate: type === 'TODO' || type === 'CHORE' || type === 'EVENT',
     showRecurrenceRule: type === 'CHORE',
+    ...(type === 'TODO' || type === 'GROCERY' || type === 'CHORE' || type === 'EVENT' ? { showResponsibility: true } : {}),
     ...(type === 'GROCERY' ? { showQuantity: true, showCategory: true } : {})
   };
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -46,6 +46,8 @@
     "category": "Kategorie",
     "uncategorized": "Ohne Kategorie",
     "dueDate": "Fällig am",
+    "ownerLabel": "Owner / verantwortlich",
+    "assistantLabels": "Assistenten / Helfer",
     "previewUrl": "URL-Vorschau",
     "search": "Einträge suchen",
     "searchPlaceholder": "Name, Notizen, Kategorie oder URL",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -46,6 +46,8 @@
     "category": "Category",
     "uncategorized": "Uncategorized",
     "dueDate": "Due date",
+    "ownerLabel": "Owner / responsible",
+    "assistantLabels": "Assistants / helpers",
     "previewUrl": "Preview URL",
     "search": "Search items",
     "searchPlaceholder": "Name, notes, category, or URL",


### PR DESCRIPTION
## Summary
- add optional `ownerLabel` and `assistantLabels` item responsibility metadata
- persist labels via Flyway/JPA/API and expose them in frontend create/edit/item rows
- document generic list owner vs item owner vs assistant/helper semantics for self-hosted households/teams

## Test Plan
- `mvn test -q`
- `npm test`
- `npm run build`
- Markdown link check
- `git diff --check`
- local browser smoke of the Vite frontend
