### PR TITLE
docs: document responsibility metadata and Alice deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Self-hosted, multi-tenant list management for wishlists, to-do lists, grocery li
 
 ## Status
 
-Current MVP/post-MVP foundation includes Spring Boot backend, Vue frontend, SQLite persistence, session auth, owner/shared list and item workflows, public link modes (`VIEW`, `WISH_CLAIM`, `SIGNUP`), list duplication, item search/filter/sort review controls, URL metadata scraping, date/time reminders for actionable list types, grocery quantity/category fields, admin settings/user management, security hardening, CI dependency scanning, and the single-container Docker build path. The current deployment posture is private Tailnet/self-hosted; see the current state and risk register for weak points before treating it as internet-ready.
+Current MVP/post-MVP foundation includes Spring Boot backend, Vue frontend, SQLite persistence, session auth, owner/shared list and item workflows, public link modes (`VIEW`, `WISH_CLAIM`, `SIGNUP`), list duplication, item search/filter/sort review controls, URL metadata scraping, date/time reminders for actionable list types, grocery quantity/category fields, item responsibility labels for work-style lists, admin settings/user management, security hardening, CI dependency scanning, and the single-container Docker build path. The current deployment posture is private Tailnet/self-hosted; see the current state and risk register for weak points before treating it as internet-ready.
 
 ## Quickstart
 
@@ -66,6 +66,7 @@ Domain and architecture:
 - [Architecture](docs/architecture.md)
 - [API](docs/api.md)
 - [Domain model](docs/domain/domain-model.md)
+- [Item responsibility metadata](docs/domain/item-responsibility.md)
 - [Permissions and sharing](docs/domain/permissions-and-sharing.md)
 - [List types](docs/domain/list-types.md)
 - [Scraping](docs/domain/scraping.md)
@@ -73,6 +74,7 @@ Domain and architecture:
 - [Security architecture](docs/architecture/security.md)
 - [Architecture decisions](docs/architecture/architecture-decision-records.md)
 - [Release verification](docs/release.md)
+- [Alice Tailnet deployment](docs/deployment/alice-tailnet.md)
 
 Planning:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -211,7 +211,7 @@ Type validation:
 - `CHORE` items reject shopping fields and allow `dueDate` plus `recurrenceRule`.
 - Supported chore recurrence rules are `FREQ=DAILY`, `FREQ=WEEKLY`, `FREQ=BIWEEKLY`, `FREQ=MONTHLY`, `FREQ=QUARTERLY`, and `FREQ=ANNUALLY`.
 - `EVENT` items reject shopping fields and `recurrenceRule`, and allow `dueDate`.
-- `ownerLabel` and `assistantLabels` are optional coordination metadata for work-style items. They may name people, roles, bots, or local automations; they do not grant access or notification rights.
+- `ownerLabel` and `assistantLabels` are optional coordination metadata for work-style items. They may name people, roles, bots, or local automations; they do not grant access or notification rights. See [Item Responsibility Metadata](domain/item-responsibility.md) for the full semantics.
 
 ### `PUT /api/v1/items/{id}`
 

--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -57,6 +57,17 @@ Index every authorization lookup path:
 
 All mutable state must live under `/app/data`. A self-hoster can back up the SQLite file and any future files under the same directory.
 
+For schema-changing deployments, copy the live SQLite database before replacing the container and test additive migrations on the copy when practical. The Alice Tailnet runbook documents the concrete backup and post-deploy migration verification flow.
+
+## Current item responsibility columns
+
+Migration `V12__add_item_responsibility_labels.sql` adds nullable item-level responsibility metadata:
+
+- `owner_label`
+- `assistant_labels`
+
+These fields are free-text coordination labels. They are not foreign keys to users, do not create shares, and do not affect authorization. Access remains inherited from the parent list and its internal/public sharing rules.
+
 ## SQLite caveats
 
 - Prefer explicit migrations over generated schema.

--- a/docs/current-state-and-risk-register.md
+++ b/docs/current-state-and-risk-register.md
@@ -1,6 +1,6 @@
 # Current State and Risk Register
 
-Last updated: 2026-09-04 on current `main`.
+Last updated: 2026-09-05 on current `main`.
 
 This document describes what exists in the repository and the Alice deployment today. It intentionally includes weak points and deferred hardening work so the current state is not over-sold.
 
@@ -14,6 +14,7 @@ Current production-like deployment is a private self-hosted MVP on Alice:
 - Alice container: `listful-thinking-alice` using image `listful-thinking:alice`.
 - Alice bind address is Tailnet-only: `100.123.149.120:8080->8080/tcp`.
 - Latest live health check returned `{"status":"ok"}`.
+- Deployment runbook: [Alice Tailnet Deployment](deployment/alice-tailnet.md).
 
 This is considered acceptable for a family/private Tailnet MVP. It is not yet a public-internet deployment profile.
 
@@ -36,6 +37,7 @@ Implemented and verified MVP/post-MVP features include:
 - Due-date reminders with SMTP-or-in-app fallback and owner-scoped notifications.
 - Grocery quantity/category fields and clear-completed workflow.
 - Operational chore recurrence including daily, weekly, biweekly, monthly, quarterly, and annual intervals.
+- Optional item responsibility labels (`ownerLabel`, `assistantLabels`) for work-style `TODO`, `CHORE`, and `EVENT` items. These labels are coordination metadata only; list ownership and sharing remain the authorization model.
 
 ## Current security controls
 
@@ -67,13 +69,16 @@ These are known and intentionally documented:
 6. **GitHub Actions deprecation warnings remain.** GitHub warns about Node 20/runtime deprecations for some `uses:` actions and `setup-java@v4` deprecation. This is maintenance noise, not a failing gate.
 7. **`npm audit` is an external availability gate.** CI intentionally fails closed if the npm registry audit endpoint returns 503 or times out. OSV scanning is a second dependency gate, but a transient npm registry outage can still make the frontend job red without any code/documentation regression.
 8. **Scraping is intentionally best-effort.** Many shops block server-side/data-center requests or return stale/generic pages. There is no browser automation, no cookie/proxy workflow, no confidence score, and no per-shop plugin architecture.
-9. **Admin support access is intentionally limited.** Admins can manage users/settings and see list metadata inventory, but do not have a general audited content-superuser workflow.
-10. **Backups/encryption are outside this repository.** The app uses a persistent SQLite volume; backup retention, backup encryption, and host hardening belong to the deployment environment.
+9. **Responsibility labels are not structured actors yet.** `ownerLabel` and `assistantLabels` are free-text metadata. Structured members, assistant agents, notification routing, rotations, and permissions remain future slices.
+10. **Admin support access is intentionally limited.** Admins can manage users/settings and see list metadata inventory, but do not have a general audited content-superuser workflow.
+11. **Backups/encryption are outside this repository.** The app uses a persistent SQLite volume; backup retention, backup encryption, and host hardening belong to the deployment environment.
 
 ## Verification evidence
 
 Recent verified implementation gates:
 
+- GitHub Actions run `33962767179` passed on merged `main` commit `5a8c1f1` for the item responsibility implementation.
+- Alice deployment of `5a8c1f1` was verified with health, browser load, packaged asset markers, Flyway version `12`, `owner_label`/`assistant_labels` columns, item-count preservation, and Tailnet-only binding.
 - `mvn -q test` passed locally after the current hardening/public-share work.
 - `npm test && npm run build && npm audit --omit=dev` passed locally.
 - `scripts/smoke.sh` passed with health, non-root runtime, admin/users/settings, list clone, item/chore recurrence, grocery clear-completed, public claim/signup, and SQLite volume checks.

--- a/docs/deployment/alice-tailnet.md
+++ b/docs/deployment/alice-tailnet.md
@@ -1,0 +1,194 @@
+# Alice Tailnet Deployment
+
+This document records the current private deployment contract for the Listful Thinking instance on Alice and the safe redeploy procedure.
+
+The Alice instance is a private Tailnet MVP deployment, not a public-internet production profile.
+
+## Live contract
+
+Observed deployment contract:
+
+- Host: Alice
+- Tailnet IP: `100.123.149.120`
+- Tailnet URL: `http://alice.taileb20d9.ts.net:8080`
+- Container name: `listful-thinking-alice`
+- Image tag: `listful-thinking:alice`
+- Port binding: `100.123.149.120:8080->8080/tcp`
+- Restart policy: `unless-stopped`
+- Persistent volume: `listful-thinking-alice-data:/app/data`
+- SQLite database: `/app/data/listful-thinking.sqlite`
+- Runtime user: non-root application user from the Docker image
+
+The service is intentionally bound to Alice's Tailscale address only. A LAN check against `192.168.10.126:8080` should not respond unless the deployment policy changes.
+
+## Important environment keys
+
+Preserve existing application environment values when recreating the container. The live container may not set every optional key.
+
+Application keys seen or supported:
+
+- `SYSTEM_LANG`
+- `SPRING_DATASOURCE_URL`
+- `LISTFUL_DB_PATH`
+- `REGISTRATION_ENABLED`
+- `PUBLIC_BASE_URL`
+- `MAIL_HOST`
+- `MAIL_PORT`
+- `MAIL_USER`
+- `MAIL_PASS`
+
+Do not print secrets such as `MAIL_PASS` into logs or chat. If an env file is used during deployment, create it with mode `0600` and remove it after `docker run` succeeds.
+
+## Pre-deploy checks
+
+Run from the repository root on Alice:
+
+```bash
+git status --short --branch
+git log --oneline -1 --decorate
+docker ps --filter name=listful-thinking-alice \
+  --format 'container={{.Names}} status={{.Status}} ports={{.Ports}} image={{.Image}}'
+python3 - <<'PY'
+import json, subprocess
+info = json.loads(subprocess.check_output(['docker', 'inspect', 'listful-thinking-alice']))[0]
+print('ports=', info['HostConfig']['PortBindings'])
+print('restart=', info['HostConfig']['RestartPolicy'])
+print('mounts=', [(m['Type'], m.get('Name'), m.get('Destination')) for m in info['Mounts']])
+print('env_keys=', sorted(e.split('=', 1)[0] for e in info['Config']['Env']))
+PY
+```
+
+For schema-changing releases, copy the live database before replacing the container and test the new migration against the copy:
+
+```bash
+backup_dir="$HOME/backups/listful-thinking"
+mkdir -p "$backup_dir"
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+docker cp listful-thinking-alice:/app/data/listful-thinking.sqlite \
+  "$backup_dir/listful-thinking-${stamp}-pre-deploy.sqlite"
+```
+
+## Build and package verification
+
+Build the merged source into the live image tag:
+
+```bash
+docker build -t listful-thinking:alice .
+```
+
+For frontend/backend changes, inspect the packaged JAR before restarting the live container:
+
+```bash
+tmp="$(mktemp -d)"
+cid="$(docker create listful-thinking:alice)"
+docker cp "$cid":/app/listful-thinking.jar "$tmp/listful-thinking.jar"
+docker rm "$cid" >/dev/null
+python3 - <<'PY' "$tmp/listful-thinking.jar"
+import sys, zipfile
+jar = sys.argv[1]
+with zipfile.ZipFile(jar) as z:
+    names = z.namelist()
+    body = '\n'.join(
+        z.read(n).decode('utf-8', errors='ignore')
+        for n in names
+        if n.startswith('BOOT-INF/classes/static/assets/') and n.endswith('.js')
+    )
+    print('has V12 migration:', 'BOOT-INF/classes/db/migration/V12__add_item_responsibility_labels.sql' in names)
+    print('has ownerLabel:', 'ownerLabel' in body)
+    print('has assistantLabels:', 'assistantLabels' in body)
+PY
+rm -rf "$tmp"
+```
+
+Adjust the markers for the feature being deployed.
+
+## Recreate container
+
+Use the live contract, not a generic compose file, for the Alice Tailnet deployment:
+
+```bash
+docker rm -f listful-thinking-alice
+
+docker run -d --name listful-thinking-alice --restart unless-stopped \
+  -p 100.123.149.120:8080:8080 \
+  -e SPRING_DATASOURCE_URL=jdbc:sqlite:/app/data/listful-thinking.sqlite \
+  -e REGISTRATION_ENABLED=false \
+  -e PUBLIC_BASE_URL=http://alice.taileb20d9.ts.net:8080 \
+  -v listful-thinking-alice-data:/app/data \
+  listful-thinking:alice
+```
+
+If the existing container has a different supported app env key/value, preserve the observed value instead of blindly using the example.
+
+## Post-deploy verification
+
+Wait for health:
+
+```bash
+for i in $(seq 1 60); do
+  if curl -fsS http://alice.taileb20d9.ts.net:8080/api/v1/health; then
+    echo "health ok after ${i}s"
+    break
+  fi
+  sleep 1
+done
+```
+
+Verify the deployed frontend asset, using the actual asset path from `/`:
+
+```bash
+curl -fsS -o /tmp/listful-live-index.html http://alice.taileb20d9.ts.net:8080/
+python3 - <<'PY'
+from pathlib import Path
+import re, urllib.request
+html = Path('/tmp/listful-live-index.html').read_text()
+assert 'Listful Thinking' in html
+asset = re.findall(r'src="(/assets/[^"]+\.js)"', html)[0]
+body = urllib.request.urlopen('http://alice.taileb20d9.ts.net:8080' + asset, timeout=20).read().decode('utf-8', 'ignore')
+for marker in ['ownerLabel', 'assistantLabels', 'Owner / responsible', 'Assistants / helpers']:
+    assert marker in body, marker
+    print(marker, 'ok')
+PY
+```
+
+Verify live SQLite migration state after schema releases:
+
+```bash
+tmp="$(mktemp -d)"
+docker cp listful-thinking-alice:/app/data/listful-thinking.sqlite "$tmp/db.sqlite"
+python3 - <<'PY' "$tmp/db.sqlite"
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+print(con.execute('select version, description, success from flyway_schema_history order by installed_rank desc limit 3').fetchall())
+cols = [r[1] for r in con.execute('pragma table_info(items)').fetchall()]
+assert 'owner_label' in cols
+assert 'assistant_labels' in cols
+print('item_count=', con.execute('select count(*) from items').fetchone()[0])
+PY
+rm -rf "$tmp"
+```
+
+Verify the running container still matches the current image tag and Tailnet-only exposure:
+
+```bash
+python3 - <<'PY'
+import json, subprocess
+info = json.loads(subprocess.check_output(['docker', 'inspect', 'listful-thinking-alice']))[0]
+tag = json.loads(subprocess.check_output(['docker', 'image', 'inspect', 'listful-thinking:alice']))[0]['Id']
+assert info['Image'] == tag
+print('running image matches tag')
+PY
+curl -fsS --max-time 10 http://alice.taileb20d9.ts.net:8080/api/v1/health
+curl -fsS --max-time 2 http://192.168.10.126:8080/api/v1/health \
+  && { echo 'unexpected LAN listener'; exit 1; } \
+  || echo 'not listening on LAN'
+```
+
+A final browser smoke should load `http://alice.taileb20d9.ts.net:8080/` and show the `Listful Thinking` login screen.
+
+## Current known deployment limitations
+
+- Alice serves Tailnet HTTP. Internet-facing use needs HTTPS/TLS termination, secure cookies, and a public deployment hardening pass.
+- Backup retention and encryption are host operations outside the repository.
+- The Docker image/JAR is not signed and no SBOM is published.
+- Admin support access remains intentionally metadata-focused.

--- a/docs/domain/domain-model.md
+++ b/docs/domain/domain-model.md
@@ -84,6 +84,8 @@ Rules:
 - `assistant_labels` records optional helpers or assistants that can support or watch the item. Assistants can be people, roles, bots, or local automations; they do not receive permissions by being named here.
 - Responsibility labels are display/coordination metadata only. Authorization still follows the parent list and internal/public share rules.
 
+See [Item Responsibility Metadata](item-responsibility.md) for the full current contract, migration, supported list types, and future structured-actor direction.
+
 ## Settings
 
 Settings are global key/value entries.

--- a/docs/domain/item-responsibility.md
+++ b/docs/domain/item-responsibility.md
@@ -1,0 +1,130 @@
+# Item Responsibility Metadata
+
+This document describes the current owner/responsible and assistant/helper feature as implemented today.
+
+## Purpose
+
+Listful Thinking supports optional responsibility labels on work-style items so small self-hosted groups can coordinate who is accountable for a task and who may help with it.
+
+The model is deliberately generic. A self-hosted instance may represent a family, couple, shared house, care team, club, small volunteer group, or small work team. The product language therefore avoids hardcoded people and avoids assuming that every actor is a family member.
+
+## Fields
+
+Item responsibility is stored on `items` as nullable text fields:
+
+- `owner_label`: user-visible label for the person, role, group, bot, or automation responsible for making sure the item happens.
+- `assistant_labels`: user-visible label or comma-separated free-text labels for helpers, assistants, bots, or automations that support the item.
+
+API field names are camelCase:
+
+- `ownerLabel`
+- `assistantLabels`
+
+Both fields are optional. Existing items keep `null` values after migration.
+
+## Semantics
+
+### List owner vs item responsibility owner
+
+The registered account that owns a list is still the access-control owner. This is the account that can edit list metadata, delete the list, manage shares, and manage public links.
+
+`ownerLabel` is different. It is item-level coordination metadata. It can say who is responsible for a task inside the household/team context, but it does not change authorization.
+
+Example:
+
+```json
+{
+  "name": "Prepare guest room",
+  "dueDate": "2027-03-12T16:00:00Z",
+  "ownerLabel": "Host on duty",
+  "assistantLabels": "Cleaning robot, reminder bot"
+}
+```
+
+### Assistants/helpers
+
+`assistantLabels` records optional supporting actors. Helpers may be humans, roles, software assistants, local automations, or bots. Naming an assistant is not the same as granting access, sending a notification, or configuring automation.
+
+The current slice treats assistants as labels only. Future versions can add structured actors, notification routing, task rotation, or automation integrations without changing the meaning of the current fields.
+
+## Supported list types
+
+The frontend shows responsibility fields for work-style item types:
+
+- `TODO`
+- `CHORE`
+- `EVENT`
+
+The backend stores the fields at item level so the data model stays simple and migration-safe. UI visibility decides where the fields are normally useful.
+
+`WISH` and `GROCERY` do not currently show these fields in the normal item form. Wishlist gift coordination still uses claim/purchased status; grocery lists focus on quantity, category, and shopping flow.
+
+## Permissions and privacy
+
+Responsibility labels do not grant permissions.
+
+- They do not create a registered user.
+- They do not create an internal share.
+- They do not create a public link.
+- They do not route reminders.
+- They do not override owner/contributor/read-only access checks.
+
+Access remains governed by the parent list:
+
+- list owner
+- internal `READ` / `CONTRIBUTE` shares
+- public link mode (`VIEW`, `WISH_CLAIM`, `SIGNUP`)
+
+Because labels are user-visible item metadata, instance users should avoid putting secrets, passwords, private addresses, or sensitive personal data into them.
+
+## Persistence and migration
+
+Migration `V12__add_item_responsibility_labels.sql` adds:
+
+```sql
+ALTER TABLE items ADD COLUMN owner_label TEXT;
+ALTER TABLE items ADD COLUMN assistant_labels TEXT;
+```
+
+The migration is additive and preserves existing rows. The Alice deploy preflight applied the migration to a copied SQLite database, confirmed the existing item count was preserved, then verified the live database after deployment.
+
+## Validation and limits
+
+The request DTO accepts both fields as optional strings with the same general style of bounded text validation used for item text fields.
+
+Recommended use:
+
+- Keep labels short and readable.
+- Prefer names, roles, or automation labels over long instructions.
+- Put details in the item description instead of overloading `assistantLabels`.
+
+## Current implementation files
+
+Backend:
+
+- `backend/src/main/resources/db/migration/V12__add_item_responsibility_labels.sql`
+- `backend/src/main/java/app/listful/domain/Item.java`
+- `backend/src/main/java/app/listful/items/dto/ItemRequest.java`
+- `backend/src/main/java/app/listful/items/dto/ItemResponse.java`
+- `backend/src/main/java/app/listful/items/ItemService.java`
+
+Frontend:
+
+- `frontend/src/App.vue`
+- `frontend/src/api/client.ts`
+- `frontend/src/listTypes.ts`
+- `frontend/src/locales/en.json`
+- `frontend/src/locales/de.json`
+
+Tests and smoke coverage:
+
+- `backend/src/test/java/app/listful/items/ItemControllerTests.java`
+- `backend/src/test/java/app/listful/persistence/SchemaMigrationTests.java`
+- `frontend/src/App.ownerAssistants.test.js`
+- `frontend/src/api/client.test.ts`
+- `frontend/src/listTypes.test.ts`
+- `scripts/smoke.sh`
+
+## Future-compatible direction
+
+A later structured actor model can add records such as members, roles, assistant agents, notification preferences, rotations, and permissions. That should be a separate design slice. The current labels are intentionally lightweight coordination metadata so the MVP can support real use now without prematurely hardcoding a family model or a bot platform.

--- a/docs/release.md
+++ b/docs/release.md
@@ -37,6 +37,7 @@ The smoke covers:
 - registration setting toggle
 - owner list creation
 - item creation
+- item responsibility labels (`ownerLabel`, `assistantLabels`) for work-style list items
 - public share token creation with explicit `WISH_CLAIM` and `SIGNUP` modes
 - unauthenticated guest wishlist claim and non-wishlist signup
 - SQLite DB file under `/app/data`
@@ -50,6 +51,19 @@ docker compose up --build
 ```
 
 Then open <http://localhost:8080>, register the first admin, and verify the workspace loads.
+
+## Alice Tailnet deployment
+
+The private Alice deployment is not driven by the repository Docker Compose file. It is a direct single-container Tailnet deployment that preserves the existing container name, Tailscale-only port binding, restart policy, and persistent SQLite volume.
+
+Use [Alice Tailnet Deployment](deployment/alice-tailnet.md) when deploying to Alice. At minimum, verify:
+
+- `listful-thinking-alice` is recreated from the merged `listful-thinking:alice` image.
+- `100.123.149.120:8080->8080/tcp` remains the only app port binding.
+- `/api/v1/health` returns `{"status":"ok"}`.
+- The root page loads and the production JS asset contains markers for the changed feature.
+- For schema releases, the live SQLite database has the expected Flyway version and columns after deployment.
+- The LAN IP does not answer on port `8080` while the service is meant to be Tailnet-only.
 
 ## Security test matrix
 
@@ -76,6 +90,7 @@ Implemented automated coverage:
 - API responses include CSP, referrer policy, and permissions policy headers.
 - Filter-level security rejects are written to `security_events`.
 - Notifications are owner-scoped.
+- Responsibility labels are preserved through item create/update/read paths and remain authorization-neutral.
 
 Known weak points and future hardening:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -127,6 +127,7 @@ Typical user actions:
 
 - Add a task.
 - Add an optional due date/time.
+- Add an optional owner/responsible label and assistants/helpers label for coordination.
 - Receive reminders for due items.
 - Mark task status as it changes.
 
@@ -134,6 +135,8 @@ Fields:
 
 - name
 - due date/time
+- owner / responsible label
+- assistants / helpers label
 - status
 
 TODO lists do not use shopping fields or recurrence rules.
@@ -178,13 +181,14 @@ Shop mode:
 
 ### CHORE
 
-Use for household work and recurring duties.
+Use for household, shared-house, care-team, club, or small-team work and recurring duties.
 
 Typical user actions:
 
 - Add a chore.
 - Add a due date/time.
 - Add a recurrence rule such as `FREQ=WEEKLY`.
+- Add who is responsible and which people, roles, bots, or automations may assist.
 - Receive reminders for due chores.
 
 Fields:
@@ -192,6 +196,8 @@ Fields:
 - name
 - due date/time
 - recurrence rule
+- owner / responsible label
+- assistants / helpers label
 - status
 
 CHORE lists do not use shopping fields.
@@ -225,6 +231,8 @@ Fields:
 - list target date
 - item name
 - item due date/time
+- owner / responsible label
+- assistants / helpers label
 - status
 
 EVENT items do not use shopping fields or recurrence rules in the MVP.
@@ -237,6 +245,13 @@ Status meaning:
 ## Working with items
 
 List owners can edit their own items after creation. The edit form shows the same type-specific fields as the create form, so grocery items expose quantity/category, wish items expose URL/image/price, and dated items expose due-date controls.
+
+For work-style item types (`TODO`, `CHORE`, and `EVENT`), the item form also shows optional responsibility labels:
+
+- **Owner / responsible**: the person, role, group, bot, or automation accountable for making sure the item happens.
+- **Assistants / helpers**: optional supporting people, roles, bots, or local automations.
+
+These labels are coordination metadata only. They do not create accounts, grant permissions, create shares, or route reminders. Access still follows the parent list owner, internal shares, and public-link mode.
 
 Use the item review controls on a selected list to keep longer lists navigable:
 
@@ -416,10 +431,11 @@ The inventory is not a private item-content browser.
 
 ### Private household chores
 
-1. User creates a `CHORE` list called `Household`.
+1. User creates a `CHORE` list called `Household` or `Shared house`.
 2. User adds `Water plants` with a due date and recurrence rule.
-3. The app reminds the user when the chore is due.
-4. The owner can share the list read-only with another local account.
+3. User adds a neutral responsibility label such as `Plant owner`, `Kitchen team`, or `Reminder bot`.
+4. The app reminds the list owner when the chore is due.
+5. The list owner can share the list read-only or contributor-enabled with another local account.
 
 ## Which list type should I choose?
 
@@ -505,6 +521,7 @@ Admins can see user and list metadata needed to operate the instance. The curren
 
 - Public guest mutation is intentionally narrow: `WISH_CLAIM` only reserves wishlist items, `SIGNUP` only reserves non-wishlist items, and `VIEW` does not allow guest changes.
 - Grocery lists support quantity/category, category grouping, done/reopen, hide-completed, and clear-completed flows, but not offline-first live collaborative shopping.
+- Responsibility fields are free-text labels only. Structured household/team members, task rotation, assistant automation, and notification routing are future slices.
 - Item review controls are client-side; very large lists may later need backend query parameters.
 - Chore recurrence supports daily, weekly, biweekly, monthly, quarterly, and annual flows; broader calendar-style recurrence remains a future extension.
 - Email features require SMTP configuration; otherwise the app stays functional with password login and in-app notifications.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -209,12 +209,13 @@ chore_json="$(curl_json -b "$admin_cookie" -H 'Content-Type: application/json' \
   "$base_url/api/v1/lists")"
 chore_id="$(printf '%s' "$chore_json" | json_field id)"
 chore_item_json="$(curl_json -b "$admin_cookie" -H 'Content-Type: application/json' \
-  -d '{"name":"Water plants","dueDate":"2027-01-01T09:00:00Z","recurrenceRule":"FREQ=BIWEEKLY"}' \
+  -d '{"name":"Water plants","dueDate":"2027-01-01T09:00:00Z","recurrenceRule":"FREQ=BIWEEKLY","ownerLabel":"Plant owner","assistantLabels":"Reminder bot"}' \
   "$base_url/api/v1/lists/$chore_id/items")"
+printf '%s' "$chore_item_json" | assert_json 'data["ownerLabel"] == "Plant owner" and data["assistantLabels"] == "Reminder bot"'
 chore_item_id="$(printf '%s' "$chore_item_json" | json_field id)"
 curl_json -b "$admin_cookie" -X PUT -H 'Content-Type: application/json' \
-  -d '{"name":"Water plants","status":"DONE","dueDate":"2027-01-01T09:00:00Z","recurrenceRule":"FREQ=BIWEEKLY"}' \
-  "$base_url/api/v1/items/$chore_item_id" | assert_json 'data["status"] == "OPEN" and data["dueDate"] == "2027-01-15T09:00:00Z" and data["lastCompletedAt"]'
+  -d '{"name":"Water plants","status":"DONE","dueDate":"2027-01-01T09:00:00Z","recurrenceRule":"FREQ=BIWEEKLY","ownerLabel":"Plant owner","assistantLabels":"Reminder bot"}' \
+  "$base_url/api/v1/items/$chore_item_id" | assert_json 'data["status"] == "OPEN" and data["dueDate"] == "2027-01-15T09:00:00Z" and data["lastCompletedAt"] and data["ownerLabel"] == "Plant owner" and data["assistantLabels"] == "Reminder bot"'
 curl_json -b "$admin_cookie" -X POST "$base_url/api/v1/items/$chore_item_id/skip" \
   | assert_json 'data["status"] == "OPEN" and data["dueDate"] == "2027-01-29T09:00:00Z"'
 curl_json -b "$admin_cookie" -X POST -H 'Content-Type: application/json' -d '{"days":1}' "$base_url/api/v1/items/$chore_item_id/postpone" \
@@ -282,4 +283,4 @@ curl_json -H 'Content-Type: application/json' \
 sqlite_path="$(docker compose -p "$project" -f "$compose_file" exec -T listful-thinking sh -c 'test -f /app/data/listful-thinking.sqlite && echo present')"
 [ "$sqlite_path" = "present" ] || { echo "SQLite database missing in /app/data" >&2; exit 1; }
 
-echo "Smoke OK: health, non-root runtime, admin/users/settings, list clone, list/item/chore recurrence/grocery clear-completed/public claim/signup, SQLite volume"
+echo "Smoke OK: health, non-root runtime, admin/users/settings, list clone, list/item responsibility/chore recurrence/grocery clear-completed/public claim/signup, SQLite volume"

--- a/scripts/test-smoke-contract.sh
+++ b/scripts/test-smoke-contract.sh
@@ -12,6 +12,8 @@ grep -q -- '--build' "$script" || { echo "smoke.sh must build the image" >&2; ex
 grep -q '/api/v1/health' "$script" || { echo "smoke.sh must check health" >&2; exit 1; }
 grep -q '/api/v1/auth/register' "$script" || { echo "smoke.sh must register users" >&2; exit 1; }
 grep -q '/api/v1/lists' "$script" || { echo "smoke.sh must exercise list API" >&2; exit 1; }
+grep -q 'ownerLabel' "$script" || { echo "smoke.sh must exercise item responsibility owner labels" >&2; exit 1; }
+grep -q 'assistantLabels' "$script" || { echo "smoke.sh must exercise item responsibility assistant labels" >&2; exit 1; }
 grep -q '/api/v1/admin/users' "$script" || { echo "smoke.sh must exercise admin API" >&2; exit 1; }
 grep -q '/api/v1/share' "$script" || { echo "smoke.sh must exercise public sharing" >&2; exit 1; }
 grep -q 'LISTFUL_KEEP_SMOKE' "$script" || { echo "smoke.sh must support keeping the container for debugging" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- add a focused item responsibility metadata reference
- add an Alice Tailnet deployment runbook with backup, package inspection, deploy, and live verification steps
- update README, user guide, release checklist, persistence/current-state/API docs, and smoke coverage for responsibility labels

## Test Plan
- `git diff --check`
- Markdown link check across README and docs
- `scripts/test-smoke-contract.sh`
- `scripts/smoke.sh`
- `cd backend && mvn test -q`
- `cd frontend && npm test && npm run build`
- `cd frontend && npm audit --omit=dev`
